### PR TITLE
Fix HTML generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+v4.0.1
+------------------------------
+* Fix HTML generation (#1)
+
+v4.0.0
+------------------------------
+* Initial extraction from Shoes!

--- a/lib/shoes/manual/app.rb
+++ b/lib/shoes/manual/app.rb
@@ -243,7 +243,7 @@ class Manual < Shoes
   end
 
   def html_manual
-    dir = ask_save_folder
+    dir = @app.ask_save_folder
     return unless dir
     FileUtils.mkdir_p File.join(dir, 'static')
     FileUtils.mkdir_p File.join(dir, 'snapshots')
@@ -264,7 +264,7 @@ class Manual < Shoes
   def mk_html(title, desc, methods, next_file, next_title, menu)
     man = self
     html = Nokogiri::HTML::Builder.new do |h|
-      h.html(lang: Manual::LANG) do
+      h.html(lang: LANG) do
         h.head do
           h.meta charset: 'utf-8'
           h.title "The Shoes 4 Manual // #{title}"

--- a/lib/shoes/manual/version.rb
+++ b/lib/shoes/manual/version.rb
@@ -1,5 +1,5 @@
 class Shoes
   module Manual
-    VERSION = "4.0.0"
+    VERSION = "4.0.1"
   end
 end


### PR DESCRIPTION
Fixes https://github.com/shoes/shoes4/issues/965

I was planned to remove the link and extract the HTML generation code into a separate, mostly unused class. Two things happened, though:

1) The HTML generation code is hopelessly snarled with the Manual's app class. Honestly, if I were aiming to accomplish this I'd probably just write something from scratch that reads generates off the Markdown files.
2) Turned out to be two simple fixes to get the link working again. Wahoo!

📚 ✨ 