### PR TITLE
Updating to nokogiri 1.8.1

### DIFF
--- a/shoes-manual.gemspec
+++ b/shoes-manual.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "shoes-highlighter", "~> 1.0", ">= 1.0.0"
-  spec.add_dependency "nokogiri", "~> 1.6.4.1", ">=1.6.4.1" # For converting the manual to HTML
+  spec.add_dependency "nokogiri", "~> 1.8.1" # For converting the manual to HTML
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake",    "~> 10.0"


### PR DESCRIPTION
Older ones have security issues.

Used by the `to_html` button in the manual, and confirmed nothing we're doing seems to have a problem with the new version.